### PR TITLE
Update the README to indicate which versions may have a issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ let initParams = InitParams(
 
 ## v4.5.0 (Mar 03, 2023)
 
-> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+> :warning: **DO NOT USE THIS VERSION**: There is a bug where the pending push token is removed after connecting a user.
 
 ### **Features**
 
@@ -60,7 +60,7 @@ Added the following interfaces in Polls:
 
 ## v4.4.0 (Feb 22, 2023)
 
-> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+> :warning: **DO NOT USE THIS VERSION**: There is a bug where the pending push token is removed after connecting a user.
 
 ### **Features**
 
@@ -92,13 +92,13 @@ SendbirdChat.connect(userId: userId) { user, error in
 
 ## v4.3.2 (Feb 16, 2023)
 
-> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+> :warning: **DO NOT USE THIS VERSION**: There is a bug where the pending push token is removed after connecting a user.
 
 - Fixed group channel querying with nickname filters (`nicknameContainsFilter`, `nicknameExactMatchFilter`, `nicknameExactMatchFilter`) to behave the same whether or not local caching is enabled
 
 ## v4.3.1 (Feb 15, 2023)
 
-> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+> :warning: **DO NOT USE THIS VERSION**: There is a bug where the pending push token is removed after connecting a user.
 
 - Added default value for `params` argument in each interface:
     - `BaseChannel.getMessageChangeLogs(token:params:completionHandler)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ let initParams = InitParams(
 
 ## v4.5.0 (Mar 03, 2023)
 
+> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+
 ### **Features**
 
 ### **Polls in Open Channel**
@@ -58,6 +60,8 @@ Added the following interfaces in Polls:
 
 ## v4.4.0 (Feb 22, 2023)
 
+> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+
 ### **Features**
 
 ### Disconnect Websocket only
@@ -88,9 +92,13 @@ SendbirdChat.connect(userId: userId) { user, error in
 
 ## v4.3.2 (Feb 16, 2023)
 
+> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
+
 - Fixed group channel querying with nickname filters (`nicknameContainsFilter`, `nicknameExactMatchFilter`, `nicknameExactMatchFilter`) to behave the same whether or not local caching is enabled
 
 ## v4.3.1 (Feb 15, 2023)
+
+> :warning: **DO NOT USE THIS VERSION**: There may be a problem registering a new push token.
 
 - Added default value for `params` argument in each interface:
     - `BaseChannel.getMessageChangeLogs(token:params:completionHandler)`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Commercial License](https://img.shields.io/badge/License-Commercial-brightgreen.svg)](https://github.com/sendbird/sendbird-chat-sdk-ios/blob/master/LICENSE.md)
 
-> :warning: **DO NOT USE THESE VERSIONS**: `v4.3.1`, `v4.3.2`, `v4.4.0`, `v4.5.0`. There may be a problem registering a new push token.
+> :warning: **DO NOT USE THESE VERSIONS**: `v4.3.1`, `v4.3.2`, `v4.4.0`, `v4.5.0`. There is a bug where the pending push token is removed after connecting a user.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Commercial License](https://img.shields.io/badge/License-Commercial-brightgreen.svg)](https://github.com/sendbird/sendbird-chat-sdk-ios/blob/master/LICENSE.md)
 
+> :warning: **DO NOT USE THESE VERSIONS**: `v4.3.1`, `v4.3.2`, `v4.4.0`, `v4.5.0`. There may be a problem registering a new push token.
+
 ## Table of contents
 
 1.  [Introduction](#introduction)


### PR DESCRIPTION
Certain versions of iOS SDK (4.3.1, 4.3.2, 4.4.0, 4.5.0) had an issue where the pending push token is removed after connecting a user. We changed the settings on our Sendbird server and the issue stopped happening, but just in case, we recommend updating to the latest SDK.