### PR TITLE
Release/4.9.6 -> master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.6 (Jul 21, 2023)
+### **Improvements**
+- Fixed a bug where the group channel changelogs did not update the group channel metadata
+
 ## v4.9.5 (Jul 13, 2023) 
 ### **Improvements**
 - Resolved the inconsistency between WebSocket connection state and network reachability

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdChatSDK",
-            url: "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.5/SendbirdChatSDK.xcframework.zip",
-            checksum: "738997c20f87c1fef7f3081a6370b873b38e7c57deb713750449b5d8a3520b64"
+            url: "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.6/SendbirdChatSDK.xcframework.zip",
+            checksum: "43a4dbb4528386be35007757672cfd2f14058dae9d62b7e3aabf90c0b91ec247"
         ),
     ]
 )

--- a/SendbirdChatSDK.podspec
+++ b/SendbirdChatSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = 'SendbirdChatSDK'
-  s.version      = "4.9.5"
+  s.version      = "4.9.6"
   s.summary      = 'Sendbird Chat iOS Framework'
   s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
   s.homepage     = 'https://sendbird.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Ernest Hong' => 'ernest.hong@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.5/SendbirdChatSDK.zip", :sha1 => "cd25cd0ba2afe2e0a34728eb68974b5215b7a587" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.6/SendbirdChatSDK.zip", :sha1 => "84c0176049f5598b8203c14d6e4da57c10b065b3" }
   s.requires_arc = true
   s.platform = :ios, '11.0'
   s.documentation_url = 'https://sendbird.com/docs/chat'


### PR DESCRIPTION
## v4.9.6 (Jul 21, 2023)
### **Improvements**
- Fixed a bug where the group channel changelogs did not update the group channel metadata