### PR TITLE
Release v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v4.10.0 (Aug 18, 2023)
+### **Features**
+- You can mark push notifications as delivered within the SDK, tracking delivery status.
+  - Added `SendbirdChat.markPushNotificationAsDelivered`.
+```swift
+SendbirdChat.markPushNotificationAsDelivered(remoteNotificationPayload: payload)
+```
+
+- Added 'SendbirdChat.authenticateFeed' for Sendbird Notifications
+- Added 'SendbirdChat.refreshNotificationCollections' for Sendbird Notifications
+
+### **Improvements**
+- Fixed a bug where the group channel changelogs did not update the group channel metadata
+- Added `copyMultipleFilesMessage(_:toTargetChannel:completionHandler:)`
+- Added `resendMultipleFilesMessage(_:fileUploadHandler:completionHandler:)`
+- Stability improvements.
+
 ## v4.9.6 (Jul 21, 2023)
 ### **Improvements**
 - Fixed a bug where the group channel changelogs did not update the group channel metadata

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdChatSDK",
-            url: "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.6/SendbirdChatSDK.xcframework.zip",
-            checksum: "43a4dbb4528386be35007757672cfd2f14058dae9d62b7e3aabf90c0b91ec247"
+            url: "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.10.0/SendbirdChatSDK.xcframework.zip",
+            checksum: "d84bbe8a95bc838852fcda98d4f85c3eff9457022ab5ef30196f45dd5b25e81d"
         ),
     ]
 )

--- a/SendbirdChatSDK.podspec
+++ b/SendbirdChatSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = 'SendbirdChatSDK'
-  s.version      = "4.9.6"
+  s.version      = "4.10.0"
   s.summary      = 'Sendbird Chat iOS Framework'
   s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
   s.homepage     = 'https://sendbird.com'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Ernest Hong' => 'ernest.hong@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.9.6/SendbirdChatSDK.zip", :sha1 => "84c0176049f5598b8203c14d6e4da57c10b065b3" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/v4.10.0/SendbirdChatSDK.zip", :sha1 => "3ae1b6e4db7b7f52958305373b47b7b1a6996475" }
   s.requires_arc = true
   s.platform = :ios, '11.0'
   s.documentation_url = 'https://sendbird.com/docs/chat'


### PR DESCRIPTION
### **Features**
- You can mark push notifications as delivered within the SDK, tracking delivery status.
  - Added `SendbirdChat.markPushNotificationAsDelivered`.
```swift
SendbirdChat.markPushNotificationAsDelivered(remoteNotificationPayload: payload)
```

- Added 'SendbirdChat.authenticateFeed' for Sendbird Notifications
- Added 'SendbirdChat.refreshNotificationCollections' for Sendbird Notifications

### **Improvements**
- Fixed a bug where the group channel changelogs did not update the group channel metadata
- Added `copyMultipleFilesMessage(_:toTargetChannel:completionHandler:)`
- Added `resendMultipleFilesMessage(_:fileUploadHandler:completionHandler:)`
- Stability improvements.
